### PR TITLE
Abstracted systems to TSystem partially to avoid instanceof. 

### DIFF
--- a/core/config/pmd/ruleSet.xml
+++ b/core/config/pmd/ruleSet.xml
@@ -13,6 +13,7 @@
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="ShortVariable"/>
         <exclude name="UnnecessaryConstructor"/>
+        <exclude name="EmptyMethodInAbstractClassShouldBeAbstract" />
     </rule>
 
     <!-- Rules, that have been moved into a category -->

--- a/core/src/main/se/tevej/game/model/ModelManager.java
+++ b/core/src/main/se/tevej/game/model/ModelManager.java
@@ -21,7 +21,6 @@ import main.se.tevej.game.model.entities.BuildingEntity;
 import main.se.tevej.game.model.entities.InventoryEntity;
 import main.se.tevej.game.model.entities.NoSuchBuildingException;
 import main.se.tevej.game.model.entities.WorldEntity;
-import main.se.tevej.game.model.signals.SignalListener;
 import main.se.tevej.game.model.systems.BuildBuildingSystem;
 import main.se.tevej.game.model.systems.DeleteEntitySystem;
 import main.se.tevej.game.model.systems.EntityCreator;
@@ -31,6 +30,7 @@ import main.se.tevej.game.model.systems.PaySystem;
 import main.se.tevej.game.model.systems.PopulationSystem;
 import main.se.tevej.game.model.systems.SignalHolder;
 import main.se.tevej.game.model.systems.SpawnNaturalResourceSystem;
+import main.se.tevej.game.model.systems.TSystem;
 import main.se.tevej.game.model.systems.TreeGrowthSystem;
 
 @SuppressWarnings("PMD.ExcessiveImports")
@@ -133,22 +133,20 @@ public class ModelManager implements AddToEngineListener, SignalHolder, EntityCr
     }
 
     private void initSystems() {
-        engine.addSystem(new BuildBuildingSystem());
-        engine.addSystem(new DeleteEntitySystem());
-        engine.addSystem(new PaySystem(this));
-        engine.addSystem(new NaturalResourceGatheringSystem(this));
-        engine.addSystem(new SpawnNaturalResourceSystem());
-        engine.addSystem(new TreeGrowthSystem(this, this));
-        engine.addSystem(new PopulationSystem());
-        engine.addSystem(new FoodGatheringSystem());
+        addSystem(new BuildBuildingSystem());
+        addSystem(new DeleteEntitySystem());
+        addSystem(new PaySystem(this));
+        addSystem(new NaturalResourceGatheringSystem(this));
+        addSystem(new SpawnNaturalResourceSystem());
+        addSystem(new TreeGrowthSystem(this, this));
+        addSystem(new PopulationSystem());
+        addSystem(new FoodGatheringSystem());
+    }
 
-        engine.getSystems().forEach(entitySystem -> {
-            if (entitySystem instanceof SignalListener) {
-                SignalListener signalListener = (SignalListener) entitySystem;
-                signalListener.setSignal(signal);
-                signal.add(signalListener.getSignalListener());
-            }
-        });
+    private void addSystem(TSystem system) {
+        engine.addSystem(system);
+        system.setSignal(signal);
+        signal.add(system.getSignalListener());
     }
 
     private void createStartingHome() {

--- a/core/src/main/se/tevej/game/model/systems/BuildBuildingSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/BuildBuildingSystem.java
@@ -2,9 +2,7 @@ package main.se.tevej.game.model.systems;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
-import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 
 import main.se.tevej.game.model.components.PositionComponent;
@@ -16,11 +14,8 @@ import main.se.tevej.game.model.entities.AddToEngineListener;
 import main.se.tevej.game.model.entities.BuildingEntity;
 import main.se.tevej.game.model.entities.NoSuchBuildingException;
 import main.se.tevej.game.model.signals.SignalComponent;
-import main.se.tevej.game.model.signals.SignalListener;
 
-public class BuildBuildingSystem
-    extends EntitySystem
-    implements SignalListener, AddToEngineListener, Listener<Entity> {
+public class BuildBuildingSystem extends TSystem implements AddToEngineListener {
 
     private Engine engine;
 
@@ -31,15 +26,6 @@ public class BuildBuildingSystem
     @Override
     public void addedToEngine(Engine engine) {
         this.engine = engine;
-    }
-
-    @Override
-    public void setSignal(Signal<Entity> signal) {
-    }
-
-    @Override
-    public Listener<Entity> getSignalListener() {
-        return this;
     }
 
     @Override

--- a/core/src/main/se/tevej/game/model/systems/DeleteEntitySystem.java
+++ b/core/src/main/se/tevej/game/model/systems/DeleteEntitySystem.java
@@ -2,17 +2,14 @@ package main.se.tevej.game.model.systems;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
-import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 
 import main.se.tevej.game.model.components.PositionComponent;
 import main.se.tevej.game.model.components.WorldComponent;
 import main.se.tevej.game.model.signals.SignalComponent;
-import main.se.tevej.game.model.signals.SignalListener;
 
-public class DeleteEntitySystem extends EntitySystem implements SignalListener, Listener<Entity> {
+public class DeleteEntitySystem extends TSystem {
 
     private Engine engine;
 
@@ -31,15 +28,6 @@ public class DeleteEntitySystem extends EntitySystem implements SignalListener, 
     @Override
     public void addedToEngine(Engine engine) {
         this.engine = engine;
-    }
-
-    @Override
-    public void setSignal(Signal<Entity> signal) {
-    }
-
-    @Override
-    public Listener<Entity> getSignalListener() {
-        return this;
     }
 
     @Override

--- a/core/src/main/se/tevej/game/model/systems/FoodGatheringSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/FoodGatheringSystem.java
@@ -2,7 +2,6 @@ package main.se.tevej.game.model.systems;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.utils.ImmutableArray;
 
@@ -13,7 +12,7 @@ import main.se.tevej.game.model.resources.Resource;
 import main.se.tevej.game.model.resources.ResourceType;
 
 
-public class FoodGatheringSystem extends EntitySystem {
+public class FoodGatheringSystem extends TSystem {
 
     private Engine engine;
 

--- a/core/src/main/se/tevej/game/model/systems/NaturalResourceGatheringSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/NaturalResourceGatheringSystem.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.utils.ImmutableArray;
 import com.badlogic.gdx.math.Vector2;
@@ -22,7 +21,7 @@ import main.se.tevej.game.model.resources.ResourceType;
 import main.se.tevej.game.model.signals.SignalComponent;
 import main.se.tevej.game.model.signals.SignalType;
 
-public class NaturalResourceGatheringSystem extends EntitySystem {
+public class NaturalResourceGatheringSystem extends TSystem {
 
     private Engine engine;
     private SignalHolder signalHolder;
@@ -168,5 +167,4 @@ public class NaturalResourceGatheringSystem extends EntitySystem {
             gather(gatherer, world, inventory, deltaTime);
         }
     }
-
 }

--- a/core/src/main/se/tevej/game/model/systems/PaySystem.java
+++ b/core/src/main/se/tevej/game/model/systems/PaySystem.java
@@ -4,9 +4,7 @@ import java.util.List;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
-import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 
 import main.se.tevej.game.model.components.InventoryComponent;
@@ -18,10 +16,9 @@ import main.se.tevej.game.model.components.buildings.BuildingType;
 import main.se.tevej.game.model.resources.NotEnoughResourcesException;
 import main.se.tevej.game.model.resources.Resource;
 import main.se.tevej.game.model.signals.SignalComponent;
-import main.se.tevej.game.model.signals.SignalListener;
 import main.se.tevej.game.model.signals.SignalType;
 
-public class PaySystem extends EntitySystem implements SignalListener, Listener<Entity> {
+public class PaySystem  extends TSystem {
 
     private Engine engine;
     private SignalHolder signalHolder;
@@ -63,15 +60,6 @@ public class PaySystem extends EntitySystem implements SignalListener, Listener<
     @Override
     public void addedToEngine(Engine engine) {
         this.engine = engine;
-    }
-
-    @Override
-    public void setSignal(Signal<Entity> signal) {
-    }
-
-    @Override
-    public Listener<Entity> getSignalListener() {
-        return this;
     }
 
     @Override

--- a/core/src/main/se/tevej/game/model/systems/PopulationSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/PopulationSystem.java
@@ -2,7 +2,6 @@ package main.se.tevej.game.model.systems;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.utils.ImmutableArray;
 
@@ -13,7 +12,7 @@ import main.se.tevej.game.model.resources.NotEnoughResourcesException;
 import main.se.tevej.game.model.resources.Resource;
 import main.se.tevej.game.model.resources.ResourceType;
 
-public class PopulationSystem extends EntitySystem {
+public class PopulationSystem extends TSystem {
 
     private Engine engine;
     private float gestationProgress;

--- a/core/src/main/se/tevej/game/model/systems/SpawnNaturalResourceSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/SpawnNaturalResourceSystem.java
@@ -2,9 +2,7 @@ package main.se.tevej.game.model.systems;
 
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
-import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 
 import main.se.tevej.game.model.components.NaturalResourceComponent;
@@ -15,12 +13,9 @@ import main.se.tevej.game.model.entities.NaturalResourceEntity;
 import main.se.tevej.game.model.resources.Resource;
 import main.se.tevej.game.model.resources.ResourceType;
 import main.se.tevej.game.model.signals.SignalComponent;
-import main.se.tevej.game.model.signals.SignalListener;
 import main.se.tevej.game.model.signals.SignalType;
 
-public class SpawnNaturalResourceSystem
-    extends EntitySystem
-    implements SignalListener, Listener<Entity> {
+public class SpawnNaturalResourceSystem extends TSystem {
 
     private Engine engine;
 
@@ -40,15 +35,6 @@ public class SpawnNaturalResourceSystem
     @Override
     public void addedToEngine(Engine engine) {
         this.engine = engine;
-    }
-
-    @Override
-    public void setSignal(Signal<Entity> signal) {
-    }
-
-    @Override
-    public Listener<Entity> getSignalListener() {
-        return this;
     }
 
     private void spawnNaturalResource(Entity entity) {

--- a/core/src/main/se/tevej/game/model/systems/TSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/TSystem.java
@@ -1,0 +1,29 @@
+package main.se.tevej.game.model.systems;
+
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.EntitySystem;
+import com.badlogic.ashley.signals.Listener;
+import com.badlogic.ashley.signals.Signal;
+
+import main.se.tevej.game.model.signals.SignalListener;
+
+public abstract class TSystem extends EntitySystem implements SignalListener, Listener<Entity> {
+
+    public TSystem() {
+        super();
+    }
+
+    @Override
+    public void setSignal(Signal<Entity> signal) {
+    }
+
+    @Override
+    public Listener<Entity> getSignalListener() {
+        return this;
+    }
+
+    @Override
+    public void receive(Signal<Entity> signal, Entity object) {
+
+    }
+}

--- a/core/src/main/se/tevej/game/model/systems/TreeGrowthSystem.java
+++ b/core/src/main/se/tevej/game/model/systems/TreeGrowthSystem.java
@@ -5,7 +5,6 @@ import java.util.Random;
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.EntityListener;
-import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -15,7 +14,7 @@ import main.se.tevej.game.model.components.TileComponent;
 import main.se.tevej.game.model.components.WorldComponent;
 import main.se.tevej.game.model.resources.ResourceType;
 
-public class TreeGrowthSystem extends EntitySystem implements EntityListener {
+public class TreeGrowthSystem extends TSystem implements EntityListener {
     @SuppressFBWarnings(
         value = "SS_SHOULD_BE_STATIC",
         justification = "No need to be static and checkbugs will complain if it is."


### PR DESCRIPTION
Also to clear up code.
Needed to add an exclude on a pmd rule that said that there should be no empty methods in an abstract class (LP approved of this). This was done to avoid having several empty methods in about half the systems in the game.